### PR TITLE
set up fastapi and implement first router

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__/
+.venv/
+.env
+*.log
+*.pyc
+*.pyo
+.DS_Store
+.git
+.gitignore

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,21 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+
+# Virtualenv
+.venv/
+
+# MongoDB dump/cache
+*.bson
+*.lock
+
+# Logs or temp
+*.log
+.env
+*.swp
+
+# Docker
+*.pid
+*.sock
+*.db

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,10 @@
+# server/Dockerfile
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir fastapi uvicorn motor
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/server/app/api/vocabulary.py
+++ b/server/app/api/vocabulary.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter
+from app.schema.word_schema import WordPublic
+from app.db.mongodb import db
+from app.constants import COLLECTION_NAME
+
+router = APIRouter()
+
+@router.get("/", response_model=list[WordPublic])
+async def get_vocabulary(limit: int = 10, offset: int = 0):
+    cursor = db[COLLECTION_NAME].find().skip(offset).limit(limit)
+    results = []
+    async for word in cursor:
+        results.append({
+            "id": str(word["_id"]),
+            "maori": word["maori"],
+            "english": word["english"]
+        })
+    return results

--- a/server/app/constants.py
+++ b/server/app/constants.py
@@ -1,0 +1,1 @@
+COLLECTION_NAME = "words"

--- a/server/app/data/words.json
+++ b/server/app/data/words.json
@@ -1,0 +1,252 @@
+[
+  {
+    "maori": "a",
+    "english": "of",
+    "explanation": "particle"
+  },
+  {
+    "maori": "ahau",
+    "english": "I, me",
+    "explanation": "pronoun"
+  },
+  {
+    "maori": "āhei",
+    "english": "can, be able to",
+    "explanation": "verb"
+  },
+  {
+    "maori": "ahi",
+    "english": "fire",
+    "explanation": "noun"
+  },
+  {
+    "maori": "ahiahi",
+    "english": "afternoon, evening",
+    "explanation": "noun"
+  },
+  {
+    "maori": "aho",
+    "english": "line, string",
+    "explanation": "noun"
+  },
+  {
+    "maori": "ahu",
+    "english": "heap up, foster, move",
+    "explanation": "verb"
+  },
+  {
+    "maori": "āhua",
+    "english": "shape, form",
+    "explanation": "noun"
+  },
+  {
+    "maori": "āhuatanga",
+    "english": "characteristic, feature",
+    "explanation": "noun"
+  },
+  {
+    "maori": "ai",
+    "english": "particle (used after verbs)",
+    "explanation": "grammatical particle"
+  },
+  {
+    "maori": "ao",
+    "english": "world, dawn",
+    "explanation": "noun"
+  },
+  {
+    "maori": "aonga",
+    "english": "use, benefit",
+    "explanation": "noun"
+  },
+  {
+    "maori": "arā",
+    "english": "that is, namely",
+    "explanation": "explanatory phrase"
+  },
+  {
+    "maori": "arahi",
+    "english": "to lead, guide",
+    "explanation": "verb"
+  },
+  {
+    "maori": "ariki",
+    "english": "chief, noble",
+    "explanation": "noun"
+  },
+  {
+    "maori": "aro",
+    "english": "to face, pay attention",
+    "explanation": "verb"
+  },
+  {
+    "maori": "arohanui",
+    "english": "with deep affection",
+    "explanation": "phrase"
+  },
+  {
+    "maori": "aroha",
+    "english": "love, compassion",
+    "explanation": "noun"
+  },
+  {
+    "maori": "atua",
+    "english": "god, spirit",
+    "explanation": "noun"
+  },
+  {
+    "maori": "awa",
+    "english": "river",
+    "explanation": "noun"
+  },
+  {
+    "maori": "āwhina",
+    "english": "help, assist",
+    "explanation": "verb"
+  },
+  {
+    "maori": "e",
+    "english": "hey! (vocative)",
+    "explanation": "particle"
+  },
+  {
+    "maori": "eke",
+    "english": "to climb, board",
+    "explanation": "verb"
+  },
+  {
+    "maori": "engari",
+    "english": "but, however",
+    "explanation": "conjunction"
+  },
+  {
+    "maori": "haere",
+    "english": "go, travel",
+    "explanation": "verb"
+  },
+  {
+    "maori": "haere mai",
+    "english": "welcome!",
+    "explanation": "greeting phrase"
+  },
+  {
+    "maori": "hākinakina",
+    "english": "sport",
+    "explanation": "noun"
+  },
+  {
+    "maori": "hau",
+    "english": "wind, vitality",
+    "explanation": "noun"
+  },
+  {
+    "maori": "hauora",
+    "english": "health, wellbeing",
+    "explanation": "noun"
+  },
+  {
+    "maori": "hei",
+    "english": "for (future use)",
+    "explanation": "particle"
+  },
+  {
+    "maori": "hiahia",
+    "english": "desire, want",
+    "explanation": "verb"
+  },
+  {
+    "maori": "hoa",
+    "english": "friend",
+    "explanation": "noun"
+  },
+  {
+    "maori": "hohonu",
+    "english": "deep",
+    "explanation": "adjective"
+  },
+  {
+    "maori": "hoki",
+    "english": "also, return",
+    "explanation": "verb/adverb"
+  },
+  {
+    "maori": "hōhā",
+    "english": "annoyed, frustrated",
+    "explanation": "adjective"
+  },
+  {
+    "maori": "hōiho",
+    "english": "horse",
+    "explanation": "noun"
+  },
+  {
+    "maori": "hōpara",
+    "english": "explore",
+    "explanation": "verb"
+  },
+  {
+    "maori": "huarahi",
+    "english": "road, path",
+    "explanation": "noun"
+  },
+  {
+    "maori": "hunga",
+    "english": "group of people",
+    "explanation": "noun"
+  },
+  {
+    "maori": "i",
+    "english": "in, at, from",
+    "explanation": "preposition"
+  },
+  {
+    "maori": "ia",
+    "english": "he, she",
+    "explanation": "pronoun"
+  },
+  {
+    "maori": "ihirangi",
+    "english": "content, index",
+    "explanation": "noun"
+  },
+  {
+    "maori": "ika",
+    "english": "fish",
+    "explanation": "noun"
+  },
+  {
+    "maori": "ingoa",
+    "english": "name",
+    "explanation": "noun"
+  },
+  {
+    "maori": "inu",
+    "english": "drink",
+    "explanation": "verb"
+  },
+  {
+    "maori": "iti",
+    "english": "small, little",
+    "explanation": "adjective"
+  },
+  {
+    "maori": "iwi",
+    "english": "tribe",
+    "explanation": "noun"
+  },
+  {
+    "maori": "kai",
+    "english": "food, eat",
+    "explanation": "noun/verb"
+  },
+  {
+    "maori": "kainga",
+    "english": "home",
+    "explanation": "noun"
+  },
+  {
+    "maori": "kaha",
+    "english": "strong, strength",
+    "explanation": "adjective/noun"
+  }
+]

--- a/server/app/db/mongodb.py
+++ b/server/app/db/mongodb.py
@@ -1,0 +1,8 @@
+from motor.motor_asyncio import AsyncIOMotorClient
+import os
+
+MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
+DB_NAME = "te_reo_maori"
+
+client = AsyncIOMotorClient(MONGO_URI)
+db = client[DB_NAME]

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI
+from contextlib import asynccontextmanager
+
+from app.api import vocabulary
+from app.scripts.import_words import import_words_if_empty
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    print("🚀 FastAPI startup: checking database...")
+    await import_words_if_empty()
+    yield
+    print("🛑 FastAPI shutdown (optional)")
+
+app = FastAPI(
+    title="Te Reo Māori Learning API",
+    description="RESTful API for Māori vocabulary and culture learning",
+    version="1.0.0",
+    lifespan=lifespan
+)
+
+app.include_router(
+    vocabulary.router,
+    prefix="/vocabulary",
+    tags=["Vocabulary"]
+)

--- a/server/app/schema/word_schema.py
+++ b/server/app/schema/word_schema.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+class WordPublic(BaseModel):
+    id: str
+    maori: str
+    english: str

--- a/server/app/scripts/import_words.py
+++ b/server/app/scripts/import_words.py
@@ -1,0 +1,18 @@
+from app.db.mongodb import db
+from app.constants import COLLECTION_NAME
+import json
+from pathlib import Path
+
+async def import_words_if_empty():
+    existing_count = await db[COLLECTION_NAME].count_documents({})
+    if existing_count > 0:
+        print(f"📦 Database already contains {existing_count} words. Skipping import.")
+        return
+
+    base_dir = Path(__file__).resolve().parent.parent
+    json_path = base_dir / "data" / "words.json"
+    with open(json_path) as f:
+        data = json.load(f)
+
+    await db[COLLECTION_NAME].insert_many(data)
+    print(f"✅ Imported {len(data)} words into MongoDB.")

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,29 @@
+
+version: '3.9'
+
+services:
+  mongo:
+    image: mongo:latest
+    container_name: maori-mongo
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+    restart: unless-stopped
+
+  fastapi:
+    build:
+      context: .
+    container_name: maori-fastapi
+    ports:
+      - "8000:8000"
+    depends_on:
+      - mongo
+    environment:
+      - MONGO_URI=mongodb://mongo:27017
+    volumes:
+      - .:/app
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+
+volumes:
+  mongo_data:


### PR DESCRIPTION
- set up test environments:
  - set up fastapi
  - set db
  - use docker to test the api locally
- implement first router: get vocabulary

## Summary by Sourcery

Set up a FastAPI server integrated with MongoDB, seed initial vocabulary data on startup, implement the first vocabulary router, and provide a containerized environment for local development

New Features:
- Initialize FastAPI application with lifecycle event to seed MongoDB from JSON when empty
- Implement GET /vocabulary endpoint returning a paginated list of words
- Containerize the FastAPI app and MongoDB service with Dockerfile and docker-compose

Enhancements:
- Extract MongoDB connection setup, collection constant, and Pydantic WordPublic schema into dedicated modules

Build:
- Add Dockerfile and docker-compose configuration for local development and testing