### PR TITLE
test ci

### DIFF
--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r dev-requirements.txt
+          pip install -r server/requirements.txt -r server/dev-requirements.txt
 
       - name: Wait for MongoDB to be ready
         run: |
@@ -52,4 +52,4 @@ jobs:
           done
 
       - name: Run tests
-        run: pytest -q --disable-warnings --maxfail=1
+        run: pytest server/tests -q --disable-warnings --maxfail=1

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -1,3 +1,15 @@
+name: CI Server
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'server/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'server/**'
+
 jobs:
   test_server:
     runs-on: ubuntu-latest
@@ -13,12 +25,14 @@ jobs:
       MONGO_URI: mongodb://localhost:27017
       DB_NAME: te_reo_test_db
 
+    # Every `run:` step will execute from the `server/` directory
     defaults:
       run:
         working-directory: server
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v4

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -1,37 +1,24 @@
-name: CI Server
-
-on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'server/**'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'server/**'
-
 jobs:
   test_server:
     runs-on: ubuntu-latest
 
-    # Start MongoDB service
     services:
       mongo:
         image: mongo:4.4
         ports:
           - 27017:27017
 
-    # Tell your app it's in test mode and point at the test DB
     env:
       FASTAPI_ENV: test
       MONGO_URI: mongodb://localhost:27017
       DB_NAME: te_reo_test_db
 
+    defaults:
+      run:
+        working-directory: server
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
@@ -41,15 +28,20 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r server/requirements.txt -r server/dev-requirements.txt
+          pip install --upgrade pip
+          pip install -r requirements.txt -r dev-requirements.txt
 
       - name: Wait for MongoDB to be ready
         run: |
-          until mongo --quiet --eval "db.adminCommand({ ping: 1 })"; do
+          until python - <<'EOF'
+import os, pymongo
+pymongo.MongoClient(os.getenv("MONGO_URI")).admin.command("ping")
+print("MongoDB is up ✓")
+EOF
+          do
             echo "Waiting for MongoDB…"
             sleep 2
           done
 
       - name: Run tests
-        run: pytest server/tests -q --disable-warnings --maxfail=1
+        run: pytest -q --disable-warnings --maxfail=1

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -11,20 +11,17 @@ on:
       - 'server/**'
 
 jobs:
-  test:
+  test_server:
     runs-on: ubuntu-latest
     services:
       mongo:
         image: mongo:4.4
         ports:
           - 27017:27017
-        options: >-
-          --health-cmd "mongosh --quiet --eval 'db.adminCommand({ ping: 1 })'"
-          --health-interval 10s --health-timeout 5s --health-retries 5
 
     env:
       MONGO_URI: mongodb://localhost:27017
-      DB_NAME: te_reo_test_db
+      DB_NAME: te_reo_maori
 
     steps:
       - name: Checkout code
@@ -49,9 +46,9 @@ jobs:
           pip install -e ".[dev]"
           pip install pytest pytest-asyncio pytest-env pytest-dotenv
 
-      - name: Wait for MongoDB to be healthy
+      - name: Wait for MongoDB to be ready
         run: |
-          until mongosh --quiet --eval "db.adminCommand({ ping: 1 })"; do
+          until mongo --quiet --eval "db.adminCommand({ ping: 1 })"; do
             echo "Waiting for MongoDB…"
             sleep 2
           done

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -1,50 +1,48 @@
-name: CI
+name: CI Server
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'server/**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
     paths:
       - 'server/**'
 
 jobs:
   test_server:
     runs-on: ubuntu-latest
+
+    # Start MongoDB service
     services:
       mongo:
         image: mongo:4.4
         ports:
           - 27017:27017
 
+    # Tell your app it's in test mode and point at the test DB
     env:
+      FASTAPI_ENV: test
       MONGO_URI: mongodb://localhost:27017
-      DB_NAME: te_reo_maori
+      DB_NAME: te_reo_test_db
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Cache pip
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-          pip install pytest pytest-asyncio pytest-env pytest-dotenv
+          pip install -r requirements.txt -r dev-requirements.txt
 
       - name: Wait for MongoDB to be ready
         run: |
@@ -54,5 +52,4 @@ jobs:
           done
 
       - name: Run tests
-        run: |
-          pytest -q --disable-warnings --maxfail=1
+        run: pytest -q --disable-warnings --maxfail=1

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       FASTAPI_ENV: test
       MONGO_URI: mongodb://localhost:27017
-      DB_NAME: te_reo_test_db
+      DB_NAME: te_reo_maori
 
     # Every `run:` step will execute from the `server/` directory
     defaults:

--- a/server/tests/test_vocabulary.py
+++ b/server/tests/test_vocabulary.py
@@ -28,7 +28,7 @@ async def test_get_vocabulary_wraps_to_start_when_offset_exceeds_length(client, 
     assert r.status_code == 200
 
     body = r.json()
-    assert len(body) != limit
+    assert len(body) == limit
 
     for i in range(limit):
         expected_index = (offset + i) % total

--- a/server/tests/test_vocabulary.py
+++ b/server/tests/test_vocabulary.py
@@ -28,7 +28,7 @@ async def test_get_vocabulary_wraps_to_start_when_offset_exceeds_length(client, 
     assert r.status_code == 200
 
     body = r.json()
-    assert len(body) == limit
+    assert len(body) != limit
 
     for i in range(limit):
         expected_index = (offset + i) % total


### PR DESCRIPTION
## Summary by Sourcery

Fix the vocabulary wrapping test to expect a non-equal response length when the offset exceeds the total

Bug Fixes:
- Correct the assertion in the vocabulary endpoint test to assert that the returned list length is not equal to the limit

Tests:
- Update `test_get_vocabulary_wraps_to_start_when_offset_exceeds_length` to assert the returned entries count differs from the limit