### PR TITLE
map client code to /

### DIFF
--- a/server/app/api/auth.py
+++ b/server/app/api/auth.py
@@ -15,7 +15,7 @@ from app.schema.auth import (
 from app.core.config import settings
 from app.utils.email import send_verification_email
 
-router = APIRouter(prefix="/auth", tags=["auth"])
+router = APIRouter(tags=["auth"])
 pwd_ctx = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 # Helper to hash passwords

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -9,15 +9,13 @@ from app.scripts.import_words import import_words_if_empty
 from app.db.mongodb import db
 from app.db.init import create_indexes
 
-# ─── 1. 定位 client/build ───────────────────────
-# __file__ = .../server/app/main.py
+# ─── 1. Locate the client/build directory ───────────────────────
 PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]  # → .../server
-PROJECT_ROOT = PROJECT_ROOT.parent                      # → project-root
 BUILD_DIR    = PROJECT_ROOT / "client" / "build"
 STATIC_DIR   = BUILD_DIR / "static"
 INDEX_FILE   = BUILD_DIR / "index.html"
 
-# ─── 2. 生命钩子（启动时初始化 DB）───────────────
+# ─── 2. Lifespan hook: initialize database at startup ────────────
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     print("🚀 startup: import words and create indexes…")
@@ -26,46 +24,46 @@ async def lifespan(app: FastAPI):
     yield
     print("🛑 shutdown")
 
-# ─── 3. 创建应用 ─────────────────────────────────
+# ─── 3. Create FastAPI application ──────────────────────────────
 app = FastAPI(
     title="Te Reo Māori Learning API",
     version="1.0.0",
     lifespan=lifespan,
 )
 
-# ─── 4. 挂载静态资源 ────────────────────────────
+# ─── 4. Mount static files ─────────────────────────────────────
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
-# ─── 5. 挂载你的业务路由 ────────────────────────
+# ─── 5. Include application routers ────────────────────────────
 app.include_router(vocabulary.router, prefix="/vocabulary", tags=["Vocabulary"])
 app.include_router(quiz.router,       prefix="/quiz",       tags=["Quiz"])
 app.include_router(auth.router,       prefix="/auth",       tags=["Authentication"])
 
-# ─── 6. 根路径，返回前端首页 ────────────────────
+# ─── 6. Root path: serve the React frontend index ──────────────
 @app.get("/", response_class=HTMLResponse)
 async def serve_index():
-    # 调试用：打印文件是否存在
+    # Debug: print whether index.html exists
     exists = INDEX_FILE.exists()
     print(f"serve_index → {INDEX_FILE} exists? {exists}")
     if not exists:
         raise HTTPException(status_code=500, detail="index.html not found")
     return HTMLResponse(INDEX_FILE.read_text(encoding="utf-8"))
 
-# ─── 7. SPA 前端路由降级：剩余请求都返回 index.html ───
+# ─── 7. SPA catch-all: return index for any unmatched frontend route ─
 @app.get("/{full_path:path}", response_class=HTMLResponse)
 async def spa_catchall(full_path: str):
-    # 下面这些都放行，让 FastAPI 自己处理
+    # These prefixes are handled by FastAPI or static files
     allowed_prefixes = (
-        "static",       # 静态资源
-        "vocabulary",   # API 路由
+        "static",       # static assets
+        "vocabulary",   # API routes
         "quiz",
         "auth",
         "docs",         # Swagger UI
-        "openapi.json", # OpenAPI 描述
+        "openapi.json", # OpenAPI spec
         "redoc",        # Redoc UI
     )
     if full_path.startswith(allowed_prefixes):
-        # 交给 FastAPI 自己去返回 404 或者文档
+        # Delegate to FastAPI for 404 or docs
         raise HTTPException(status_code=404)
-    # 其它路径返回前端首页
+    # Otherwise serve the frontend index
     return HTMLResponse(INDEX_FILE.read_text(encoding="utf-8"))

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,4 +1,7 @@
-from fastapi import FastAPI
+import pathlib
+from fastapi import FastAPI, HTTPException
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import HTMLResponse
 from contextlib import asynccontextmanager
 
 from app.api import vocabulary, quiz, auth
@@ -6,34 +9,63 @@ from app.scripts.import_words import import_words_if_empty
 from app.db.mongodb import db
 from app.db.init import create_indexes
 
+# ─── 1. 定位 client/build ───────────────────────
+# __file__ = .../server/app/main.py
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]  # → .../server
+PROJECT_ROOT = PROJECT_ROOT.parent                      # → project-root
+BUILD_DIR    = PROJECT_ROOT / "client" / "build"
+STATIC_DIR   = BUILD_DIR / "static"
+INDEX_FILE   = BUILD_DIR / "index.html"
+
+# ─── 2. 生命钩子（启动时初始化 DB）───────────────
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    print("🚀 FastAPI startup: checking database...")
+    print("🚀 startup: import words and create indexes…")
     await import_words_if_empty()
     await create_indexes(db)
     yield
-    print("🛑 FastAPI shutdown (optional)")
+    print("🛑 shutdown")
 
+# ─── 3. 创建应用 ─────────────────────────────────
 app = FastAPI(
     title="Te Reo Māori Learning API",
-    description="RESTful API for Māori vocabulary and culture learning",
     version="1.0.0",
-    lifespan=lifespan
+    lifespan=lifespan,
 )
 
-app.include_router(
-    vocabulary.router,
-    prefix="/vocabulary",
-    tags=["Vocabulary"]
-)
+# ─── 4. 挂载静态资源 ────────────────────────────
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
-app.include_router(
-    quiz.router,
-    prefix="/quiz",
-    tags=["Quiz"]
-)
+# ─── 5. 挂载你的业务路由 ────────────────────────
+app.include_router(vocabulary.router, prefix="/vocabulary", tags=["Vocabulary"])
+app.include_router(quiz.router,       prefix="/quiz",       tags=["Quiz"])
+app.include_router(auth.router,       prefix="/auth",       tags=["Authentication"])
 
-app.include_router(
-    auth.router,
-    tags=["Authentication"]
-)
+# ─── 6. 根路径，返回前端首页 ────────────────────
+@app.get("/", response_class=HTMLResponse)
+async def serve_index():
+    # 调试用：打印文件是否存在
+    exists = INDEX_FILE.exists()
+    print(f"serve_index → {INDEX_FILE} exists? {exists}")
+    if not exists:
+        raise HTTPException(status_code=500, detail="index.html not found")
+    return HTMLResponse(INDEX_FILE.read_text(encoding="utf-8"))
+
+# ─── 7. SPA 前端路由降级：剩余请求都返回 index.html ───
+@app.get("/{full_path:path}", response_class=HTMLResponse)
+async def spa_catchall(full_path: str):
+    # 下面这些都放行，让 FastAPI 自己处理
+    allowed_prefixes = (
+        "static",       # 静态资源
+        "vocabulary",   # API 路由
+        "quiz",
+        "auth",
+        "docs",         # Swagger UI
+        "openapi.json", # OpenAPI 描述
+        "redoc",        # Redoc UI
+    )
+    if full_path.startswith(allowed_prefixes):
+        # 交给 FastAPI 自己去返回 404 或者文档
+        raise HTTPException(status_code=404)
+    # 其它路径返回前端首页
+    return HTMLResponse(INDEX_FILE.read_text(encoding="utf-8"))

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -18,8 +18,13 @@ services:
       - mongo
     environment:
       - MONGO_URI=mongodb://mongo:27017
+      - SMTP_HOST=smtp.your.com
+      - SMTP_USER=you@your.com
+      - SMTP_PASSWORD=secret
+      - SMTP_SENDER=you@your.com
     volumes:
       - .:/app
+      - ../client:/client
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
 volumes:


### PR DESCRIPTION
## Summary by Sourcery

Enable the server to host the client SPA from the root path and update development environment configuration.

New Features:
- Serve built client assets at "/static" and return index.html for root and unrecognized paths to support SPA routing
- Mount authentication endpoints under "/auth" alongside existing API routers

Enhancements:
- Standardize startup and shutdown logging messages and streamline router registrations

Deployment:
- Add SMTP environment variables and mount the client directory in docker-compose for local development